### PR TITLE
fix: make tabs ssr friendly

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -107,8 +107,6 @@ export default {
       state.tabs.splice(tabIndex, 1)
     })
 
-    const storageKey = `vue-tabs-component.cache.${window.location.host}${window.location.pathname}`
-
     const selectTab = (selectedTabHash, event) => {
       if (event && !props.options.useUrlFragment) {
         event.preventDefault();
@@ -138,6 +136,7 @@ export default {
 
       state.lastActiveTabHash = state.activeTabHash = selectedTab.hash;
 
+      const storageKey = `vue-tabs-component.cache.${window.location.host}${window.location.pathname}`;
       expiringStorage.set(storageKey, selectedTab.hash, props.cacheLifetime);
     }
 
@@ -157,6 +156,7 @@ export default {
         return;
       }
 
+      const storageKey = `vue-tabs-component.cache.${window.location.host}${window.location.pathname}`;
       const previousSelectedTabHash = expiringStorage.get(storageKey);
 
       if (findTab(previousSelectedTabHash)) {


### PR DESCRIPTION
There was a dependency on `windows` object which is undefined on SSR environments (like this one: https://github.com/vuejs/vitepress/issues/621#issuecomment-1123168048) until the component is mounted. This PR fixes that issue and makes the component SSR friendly, eliminating the need to use workarounds like the `<client-only>` component.