### PR TITLE
Added inactive tab classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,11 @@ The output HTML classes can be overridden by using the following `Tabs` componen
 - `nav-class`
 - `nav-item-class`
 - `nav-item-active-class`
+- `nav-item-inactive-class`
 - `nav-item-disabled-class`
 - `nav-item-link-class`
 - `nav-item-link-active-class`
+- `nav-item-link-inactive-class`
 - `nav-item-link-disabled-class`
 
 The `Tab` content (section) class can be overridden with the `panel-class` attribute 
@@ -260,6 +262,9 @@ If no custom classes are set, the following classes are used as default:
         </li>
         <li class="tabs-component-tab is-active"> // nav-item-class + nav-item-active-class
             <a class="tabs-component-tab-a is-active">…</a> // nav-item-link-class + nav-item-link-active-class
+        </li>
+        <li class="tabs-component-tab is-inactive"> // nav-item-class + nav-item-inactive-class
+            <a class="tabs-component-tab-a is-inactive">…</a> // nav-item-link-class + nav-item-link-inactive-class
         </li>
     </ul>
     <div class="tabs-component-panels"> // panels-wrapper-class

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -7,12 +7,12 @@
       <li
         v-for="(tab, i) in tabs"
         :key="i"
-        :class="[ navItemClass, tab.isDisabled ? navItemDisabledClass : '', tab.isActive ? navItemActiveClass : '' ]"
+        :class="[ navItemClass, tab.isDisabled ? navItemDisabledClass : '', tab.isActive ? navItemActiveClass : (!tab.isDisabled ? navItemInactiveClass : '') ]"
         role="presentation"
       >
         <a
           role="tab"
-          :class="[ navItemLinkClass, tab.isDisabled ? navItemLinkDisabledClass : '', tab.isActive ? navItemLinkActiveClass : '' ]"
+          :class="[ navItemLinkClass, tab.isDisabled ? navItemLinkDisabledClass : '', tab.isActive ? navItemLinkActiveClass : (!tab.isDisabled ? navItemLinkInactiveClass : '') ]"
           :aria-controls="tab.hash"
           :aria-selected="tab.isActive"
           :href="tab.hash"
@@ -70,6 +70,10 @@ export default {
       type: String,
       default: 'is-active'
     },
+    navItemInactiveClass: {
+      type: String,
+      default: 'is-inactive'
+    },
     navItemLinkClass: {
       type: String,
       default: 'tabs-component-tab-a'
@@ -77,6 +81,10 @@ export default {
     navItemLinkActiveClass: {
       type: String,
       default: 'is-active'
+    },
+    navItemLinkInactiveClass: {
+      type: String,
+      default: 'is-inactive'
     },
     navItemLinkDisabledClass: {
       type: String,


### PR DESCRIPTION
Added extra classes for when tabs are inactive. 

This is useful for using Tailwind CSS utility classes which you want to be applied by default but then removed when the tab is active or disabled.