### PR TITLE
aria-controls fix

### DIFF
--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -2,6 +2,7 @@
   <section
     v-show="isActive"
     ref="tab"
+    :id="computedId"
     :data-tab-id="computedId"
     :aria-hidden="! isActive"
     :class="panelClass"

--- a/src/components/Tab.vue
+++ b/src/components/Tab.vue
@@ -2,7 +2,7 @@
   <section
     v-show="isActive"
     ref="tab"
-    :id="computedId"
+    :id="paneId"
     :data-tab-id="computedId"
     :aria-hidden="! isActive"
     :class="panelClass"
@@ -54,6 +54,7 @@ export default {
 
     const header = props.prefix + props.name + props.suffix
     const computedId = props.id ? props.id : props.name.toLowerCase().replace(/ /g, '-')
+    const paneId = computedId + '-pane'
     const hash = computed(() => '#' + (!props.isDisabled ? computedId : ''))
 
     watch(
@@ -70,7 +71,8 @@ export default {
         isDisabled: props.isDisabled,
         hash: hash.value,
         index: tabsProvider.tabs.length,
-        computedId: computedId
+        computedId: computedId,
+        paneId: paneId
       })
     })
 
@@ -81,7 +83,8 @@ export default {
         isDisabled: props.isDisabled,
         hash: hash.value,
         index: tabsProvider.tabs.length,
-        computedId: computedId
+        computedId: computedId,
+        paneId: paneId
       })
     })
 
@@ -92,6 +95,7 @@ export default {
     return {
       header,
       computedId,
+      paneId,
       hash,
       isActive
     }

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -13,7 +13,7 @@
         <a
           role="tab"
           :class="[ navItemLinkClass, tab.isDisabled ? navItemLinkDisabledClass : '', tab.isActive ? navItemLinkActiveClass : (!tab.isDisabled ? navItemLinkInactiveClass : '') ]"
-          :aria-controls="tab.computedId"
+          :aria-controls="tab.paneId"
           :aria-selected="tab.isActive"
           :href="tab.hash"
           @click="selectTab(tab.hash, $event)"

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -13,7 +13,7 @@
         <a
           role="tab"
           :class="[ navItemLinkClass, tab.isDisabled ? navItemLinkDisabledClass : '', tab.isActive ? navItemLinkActiveClass : (!tab.isDisabled ? navItemLinkInactiveClass : '') ]"
-          :aria-controls="tab.hash"
+          :aria-controls="tab.computedId"
           :aria-selected="tab.isActive"
           :href="tab.hash"
           @click="selectTab(tab.hash, $event)"


### PR DESCRIPTION
Proposal for fix of issue #34 

Aria-controls attribute value should not contain hash sign and tab section should have same ID so that screenreaders know the tab controls the corresponding panel.